### PR TITLE
ghd: add desktop file

### DIFF
--- a/contrib/ghd.desktop
+++ b/contrib/ghd.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=ghd
+Comment=Github Dashboard - An easy to use overview of Github
+Exec=/opt/bin/ghd
+Categories=Development


### PR DESCRIPTION
Add .desktop file.
In the current configuration it is expected that `ghd` is installed in `/opt/bin/ghd`. The .desktop file can be placed in `~/.local/share/applications` or `/usr/local/share/applications`, where the launcher or start menu of the desktop environment will be able to pick it up and generate a menu entry for ghd. Then the launcher or start menu will be able to launch ghd correctly.